### PR TITLE
Switch to using extra_state_attributes

### DIFF
--- a/custom_components/sonarr_upcoming_media/sensor.py
+++ b/custom_components/sonarr_upcoming_media/sensor.py
@@ -67,7 +67,7 @@ class SonarrUpcomingMediaSensor(Entity):
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         import re
         """Return JSON for the sensor."""
         attributes = {}


### PR DESCRIPTION
Users will start to get warned about integrations that use `device_state_attributes` in 2021.12.0