### PR TITLE
Create sensor for Sonarr 'Wanted'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,15 @@ If the above My button doesn’t work, you can also perform the following steps 
 
 ### Sample for ui-lovelace.yaml:
 
+```yaml
     - type: custom:upcoming-media-card
       entity: sensor.sonarr_upcoming_media
       title: Upcoming TV
-      
+
+    - type: custom:upcoming-media-card
+      entity: sensor.sonarr_wanted_media
+      title: Wanted TV
+```
       
 ### Card Content Defaults:
 

--- a/custom_components/sonarr_upcoming_media/parsing.py
+++ b/custom_components/sonarr_upcoming_media/parsing.py
@@ -38,7 +38,7 @@ def parse_data(data, tz, host, port, ssl, url_base=None):
         if 'series' not in show:
             continue
         card_item['airdate'] = show['airDateUtc']
-        if days_until(show['airDateUtc'], tz) <= 7:
+        if 0 <= days_until(show['airDateUtc'], tz) <= 7:
             card_item['release'] = '$day, $time'
         else:
             card_item['release'] = '$day, $date $time'

--- a/custom_components/sonarr_upcoming_media/sensor.py
+++ b/custom_components/sonarr_upcoming_media/sensor.py
@@ -20,14 +20,29 @@ async def async_setup_entry(
 ) -> None:
     coordinator: SonarrDataCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    async_add_entities([SonarrUpcomingMediaSensor(coordinator, config_entry)], update_before_add=True)
+    async_add_entities(
+        [
+            SonarrUpcomingMediaSensor(coordinator, config_entry),
+            SonarrWantedMediaSensor(coordinator, config_entry),
+        ],
+        update_before_add=True,
+    )
 
-class SonarrUpcomingMediaSensor(CoordinatorEntity[SonarrDataCoordinator], SensorEntity):
-    def __init__(self, coordinator: SonarrDataCoordinator, config_entry: ConfigEntry):
+class SonarrMediaSensor(CoordinatorEntity[SonarrDataCoordinator], SensorEntity):
+    def __init__(
+        self,
+        coordinator: SonarrDataCoordinator,
+        config_entry: ConfigEntry,
+        sensor_type: str,
+        type_name: str,
+    ):
         super().__init__(coordinator)
         self._coordinator = coordinator
-        self._name = f'{config_entry.data[CONF_NAME].capitalize() + " " if len(config_entry.data[CONF_NAME]) > 0 else ""}Sonarr Upcoming Media'
+        self._sensor_type = sensor_type
+        prefix = f'{config_entry.data[CONF_NAME].capitalize()} ' if len(config_entry.data[CONF_NAME]) > 0 else ''
+        self._name = f'{prefix}Sonarr {type_name} Media'
         self._api_key = config_entry.data[CONF_API_KEY]
+        self._unique_id = f'{self._api_key}_Sonarr_{type_name}_Media'
 
     @property
     def name(self) -> str:
@@ -37,13 +52,23 @@ class SonarrUpcomingMediaSensor(CoordinatorEntity[SonarrDataCoordinator], Sensor
     @property
     def unique_id(self) -> str:
         """Return the unique ID of the sensor."""
-        return f'{self._api_key}_Sonarr_Upcoming_Media'
+        return self._unique_id
 
     @property
     def state(self) -> Optional[str]:
         """Return the value of the sensor."""
-        return "Online" if self._coordinator.data['online'] else "Offline"
+        return "Online" if self._coordinator.data and self._coordinator.data.get('online', False) else "Offline"
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:
-        return self._coordinator.data['data']
+        if not self._coordinator.data:
+            return {}
+        return self._coordinator.data.get(self._sensor_type, self._coordinator.data.get('data', {}))
+
+class SonarrUpcomingMediaSensor(SonarrMediaSensor):
+    def __init__(self, coordinator: SonarrDataCoordinator, config_entry: ConfigEntry):
+        super().__init__(coordinator, config_entry, "upcoming", "Upcoming")
+
+class SonarrWantedMediaSensor(SonarrMediaSensor):
+    def __init__(self, coordinator: SonarrDataCoordinator, config_entry: ConfigEntry):
+        super().__init__(coordinator, config_entry, "wanted", "Wanted")

--- a/custom_components/sonarr_upcoming_media/sonarr_api.py
+++ b/custom_components/sonarr_upcoming_media/sonarr_api.py
@@ -38,34 +38,34 @@ class SonarrApi():
         tz = timezone(str(self._hass.config.time_zone))
         start = get_date(tz)
         end = get_date(tz, self._days)
-        address = 'http{0}://{1}:{2}/{3}api/v3/calendar?start={4}&end={5}&includeEpisodeImages=true&includeSeries=true'.format(
-                    's' if self._ssl else '', 
-                    self._host,
-                    self._port,
-                    "{}/".format(self._url_base.strip('/')) if self._url_base else self._url_base,
-                    start,
-                    end
-                    )
+        url_prefix = "{}/".format(self._url_base.strip('/')) if self._url_base else self._url_base
+        protocol = 's' if self._ssl else ''
+        address_calendar = f'http{protocol}://{self._host}:{self._port}/{url_prefix}api/v3/calendar?start={start}&end={end}&includeEpisodeImages=true&includeSeries=true'
+        address_wanted = f'http{protocol}://{self._host}:{self._port}/{url_prefix}api/v3/wanted/missing?page=1&pageSize={self._max}&sortKey=airDateUtc&sortDir=descending&includeSeries=true&includeImages=true'
+
         try:
-            api = requests.get(address, headers={'X-Api-Key': self._api}, timeout=10)
+            api_calendar = requests.get(address_calendar, headers={'X-Api-Key': self._api}, timeout=10)
+            api_wanted = requests.get(address_wanted, headers={'X-Api-Key': self._api}, timeout=10)
         except OSError:
             raise SonarrCannotBeReached
 
-        if api.status_code == 200:
+        if api_calendar.status_code == 200 and api_wanted.status_code == 200:
+            upcoming_raw = api_calendar.json()
             if self._days == 1:
-                return {
-                    'online': True,
-                    'data': parse_data(list(
-                                        filter(
-                                            lambda x: x['airDate'][:-10] == str(start),
-                                            api.json()))[:self._max], tz, self._host, self._port, self._ssl, self._url_base)
-                }
-                            
+                upcoming_raw = list(filter(lambda x: x.get('airDate', '')[:-10] == str(start), upcoming_raw))
+            upcoming_data = parse_data(upcoming_raw[:self._max], tz, self._host, self._port, self._ssl, self._url_base)
+
+            wanted_json = api_wanted.json()
+            wanted_records = wanted_json.get('records', wanted_json) if isinstance(wanted_json, dict) else wanted_json
+            wanted_data = parse_data(wanted_records[:self._max], tz, self._host, self._port, self._ssl, self._url_base)
+
             return {
                 'online': True,
-                'data': parse_data(api.json()[:self._max], tz, self._host, self._port, self._ssl, self._url_base)
+                'upcoming': upcoming_data,
+                'wanted': wanted_data,
+                'data': upcoming_data,
             }
-        
+
         raise SonarrCannotBeReached
 
 class FailedToLogin(Exception):


### PR DESCRIPTION
I wanted to reveal the list of "Wanted" shows from Sonarr (originally from the existing Wanted entity created by the Sonarr integration, but then I went with the API) as a second sensor so that it can be displayed in the Upcoming Media Card as well so that I can track shows that are out but that I haven't watched yet.

(Does that work for people who aren't using Sonarr to actually download media? I'm just using it as a bridge between MDBList and Home Assistant. It may be a rare use case but it's mine.)

I don't expect you the accept/merge this PR, I just wanted to bring the idea to your attention in case any of it is useful.